### PR TITLE
Ensure cron uses absolute script paths

### DIFF
--- a/check_and_record.sh
+++ b/check_and_record.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 SAT="ISS (ZARYA)"
 TLE_FILE="$HOME/iss-sstv-auto-receiver/.predict/predict.tle"
 
 if predict -t "$TLE_FILE" -p "$SAT" | awk '{if ($10 > 10) exit 0; else exit 1}'; then
     echo "Recording ISS SSTV transmission..."
-    ./record_sstv.sh
+    "$SCRIPT_DIR/record_sstv.sh"
     for f in $HOME/iss_sstv/*.wav; do
-        ./decode_sstv.sh "$f"
+        "$SCRIPT_DIR/decode_sstv.sh" "$f"
     done
 else
     echo "No pass at this time."


### PR DESCRIPTION
## Summary
- set `SCRIPT_DIR` in `check_and_record.sh`
- call helper scripts with absolute paths

## Testing
- `bash -n check_and_record.sh`

------
https://chatgpt.com/codex/tasks/task_e_6875fdaabec88331a1c956488f008f2f