### PR TITLE
Add script to auto-update TLE data

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,4 +7,6 @@ sudo apt install -y git cmake build-essential libfftw3-dev libusb-1.0-0-dev \
 mkdir -p ~/.predict
 cp .predict/predict.tle ~/.predict/
 
-(crontab -l 2>/dev/null; echo "*/10 * * * * $HOME/iss-sstv-auto-receiver/check_and_record.sh >> $HOME/iss_sstv/log.txt 2>&1") | crontab -
+(crontab -l 2>/dev/null; \
+    echo "*/10 * * * * $HOME/iss-sstv-auto-receiver/check_and_record.sh >> $HOME/iss_sstv/log.txt 2>&1"; \
+    echo "0 0 * * * $HOME/iss-sstv-auto-receiver/update_tle.sh >> $HOME/iss_sstv/tle_update.log 2>&1") | crontab -

--- a/update_tle.sh
+++ b/update_tle.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+TLE_PATH="$HOME/iss-sstv-auto-receiver/.predict/predict.tle"
+curl -L -o "$TLE_PATH" https://celestrak.org/NORAD/elements/stations.txt


### PR DESCRIPTION
## Summary
- add `update_tle.sh` to download latest station TLEs
- update `install.sh` to schedule this script daily via cron

## Testing
- `bash -n update_tle.sh`
- `bash -n install.sh check_and_record.sh decode_sstv.sh record_sstv.sh`

------
https://chatgpt.com/codex/tasks/task_e_687608857e2883319754a64282e4f581